### PR TITLE
Add capability for default Ubuntu 17.10 install

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -17,6 +17,8 @@ func Get() (string, error) {
 	switch Desktop {
 	case "GNOME", "Unity", "Pantheon", "Budgie:GNOME":
 		return parseDconf("dconf", "read", "/org/gnome/desktop/background/picture-uri")
+	case "ubuntu:GNOME":
+		return parseDconf("gsettings", "get", "org.gnome.desktop.background", "picture-uri")
 	case "KDE":
 		return parseKDEConfig()
 	case "X-Cinnamon":
@@ -43,6 +45,8 @@ func SetFromFile(file string) error {
 	switch Desktop {
 	case "GNOME", "Unity", "Pantheon", "Budgie:GNOME":
 		return exec.Command("dconf", "write", "/org/gnome/desktop/background/picture-uri", strconv.Quote("file://"+file)).Run()
+	case "ubuntu:GNOME":
+		return exec.Command("gsettings", "set", "org.gnome.desktop.background", "picture-uri", strconv.Quote("file://"+file)).Run()
 	case "KDE":
 		return setKDEBackground("file://" + file)
 	case "X-Cinnamon":


### PR DESCRIPTION
Ubuntu 17.10 has moved to Gnome3 as the default desktop.

This PR adds the identification string to handle reading and setting the wallpaper on their flavour of Gnome shell. Also uses `gsettings` rather than `dconf` as reading the default setting using `dconf` just gave me a blank string. Only started returning a value when I had already changed it from the default