### PR TITLE
Generic fix for minimal linux with feh

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -110,10 +110,13 @@ func SetFromFile(file string) error {
 		return exec.Command("pcmanfm", "-w", file).Run()
 	case "Deepin":
 		return exec.Command("dconf", "write", "/com/deepin/wrap/gnome/desktop/background/picture-uri", strconv.Quote("file://"+file)).Run()
-	case "i3":
-		return exec.Command("feh", "--bg-fill", file).Run()
 	default:
-		return ErrUnsupportedDE
+		feh, err := exec.LookPath("feh")
+		if err != nil {
+			return ErrUnsupportedDE
+		}
+
+		return exec.Command(feh, "--bg-fill", file).Run()
 	}
 }
 


### PR DESCRIPTION
Hey :) I'm the nerd who originally got `i3` support, honestly that fix was not specific to `i3`, now I use `dwm` and I was gonna use this library and it failed, so I added a case at the end for cases where `feh` is found.

If you've got any changes you want in my commit just let me know :)