### PR TITLE
Add screensaver file update for Gnome

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -84,7 +84,7 @@ func Get() (string, error) {
 // SetFromFile sets wallpaper from a file path.
 func SetFromFile(file string) error {
 	if isGNOMECompliant() {
-		return exec.Command("gsettings", "set", "org.gnome.desktop.background", "picture-uri", strconv.Quote("file://"+file)).Run()
+		return exec.Command("gsettings", "set", "org.gnome.desktop.background", "picture-uri", strconv.Quote("file://"+file), "&&", "gsettings", "set", "org.gnome.desktop.screensaver", "picture-uri", strconv.Quote("file://"+file)).Run()
 	}
 
 	switch Desktop {


### PR DESCRIPTION
Add setting screensaver lock wallpaper for Gnome. This makes the lock screen show the correct wallpaper as well.