### PR TITLE
Delete old file before downloading new image

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -44,8 +44,3 @@ func getCacheDir() (string, error) {
 
 	return filepath.Join(usr.HomeDir, "Library", "Caches"), nil
 }
-
-// cleanFilename returns s with any illegal filename characters removed.
-func cleanFilename(s string) string {
-	return strings.ReplaceAll(s, "/", "")
-}

--- a/linux.go
+++ b/linux.go
@@ -214,8 +214,3 @@ func getXFCEDesktops() ([]string, error) {
 
 	return lines, nil
 }
-
-// cleanFilename returns s with any illegal filename characters removed.
-func cleanFilename(s string) string {
-	return strings.ReplaceAll(s, "/", "")
-}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,12 @@ package wallpaper
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // Desktop contains the current desktop environment on Linux.
@@ -23,7 +25,12 @@ func downloadImage(url string) (string, error) {
 		return "", err
 	}
 
-	filename := filepath.Join(cacheDir, cleanFilename(filepath.Base(url)))
+	wallpaperDir := filepath.Join(cacheDir, "wallpaper")
+	if err = recreateDir(wallpaperDir); err != nil {
+		return "", err
+	}
+
+	filename := filepath.Join(wallpaperDir, fmt.Sprint(time.Now()))
 	file, err := os.Create(filename)
 	if err != nil {
 		return "", err
@@ -50,4 +57,23 @@ func downloadImage(url string) (string, error) {
 	}
 
 	return filename, nil
+}
+
+func recreateDir(dirName string) error {
+	if err := os.RemoveAll(dirName); err != nil {
+		return err
+	}
+	if err := ensureDir(dirName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureDir(dirName string) error {
+	err := os.MkdirAll(dirName, os.ModePerm)
+	if err == nil || os.IsExist(err) {
+		return nil
+	} else {
+		return err
+	}
 }

--- a/windows.go
+++ b/windows.go
@@ -4,7 +4,6 @@ package wallpaper
 
 import (
 	"os"
-	"regexp"
 	"strings"
 	"syscall"
 	"unicode/utf16"
@@ -70,11 +69,4 @@ func SetFromURL(url string) error {
 
 func getCacheDir() (string, error) {
 	return os.TempDir(), nil
-}
-
-var illegalRe = regexp.MustCompile(`[<>:"/\\|?*]`)
-
-// cleanFilename returns s with any illegal filename characters removed.
-func cleanFilename(s string) string {
-	return illegalRe.ReplaceAllString(s, "")
 }


### PR DESCRIPTION
## Context

Downloaded is now saved at `<cache_dir>/<file_name>` with `file_name` derived from image url.

## Problem

Dynamic images with the same requesting url (eg. [https://source.unsplash.com/random/1600x900](https://source.unsplash.com/random/1600x900)) constantly generate the same cached file (eg. `<cache_dir>/1600x900`).

On macOS, calling wallpaper changing `osascript` command with the same file name would not change the wallpaper at all, if the file is totally different from the previous file.

## Proposal

Cache file name will be named using unix timestamp. On every download, old file will be deleted, a new one will be created.

Please take a look, @reujab. Thank you!