### PR TITLE
Change the feh command to work on linux default

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -59,7 +59,7 @@ func SetFromFile(file string) error {
 			return nil
 		}
 
-		return exec.Command("feh", "-bg-fill", file).Run()
+		return exec.Command("feh", "--bg-fill", file).Run()
 	}
 }
 


### PR DESCRIPTION
The original commnad you put was "-bg-fill" but feh uses "--bg-fill". Yeah so small but it does the difference XD