### PR TITLE
Support setting the wallpaper via a running swww daemon

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -3,6 +3,7 @@
 package wallpaper
 
 import (
+	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -53,10 +54,24 @@ func SetFromFile(file string) error {
 	case "Deepin":
 		return exec.Command("dconf", "write", "/com/deepin/wrap/gnome/desktop/background/picture-uri", strconv.Quote("file://"+file)).Run()
 	default:
-		err := exec.Command("swaybg", "-i", file).Start()
-		// if the command completed successfully, return
-		if err == nil {
-			return nil
+		// Make sure we're on wayland at all, otherwise fall back to feh
+		if os.Getenv("WAYLAND_DISPLAY") != "" {
+
+			// Search for existing swww sockets which might indicate the user prefers it to swaybg
+			swwSock := os.Getenv("XDG_RUNTIME_DIR") + "/swww-" + os.Getenv("WAYLAND_DISPLAY") + ".socket"
+
+			if _, err := os.Stat(swwSock); err == nil {
+				err := exec.Command("swww", "img", file).Start()
+				if err == nil {
+					return nil
+				}
+			}
+
+			err := exec.Command("swaybg", "-i", file).Start()
+			// if the command completed successfully, return
+			if err == nil {
+				return nil
+			}
 		}
 
 		return exec.Command("feh", "-bg-fill", file).Run()


### PR DESCRIPTION
I know supporting Linux is a huge hassle but I hope this contribution still helps. While a few years ago there was only `swaybg`, with [swww](https://github.com/LGFae/swww) there is now a new tool that supports `wlr-layer-shell`.

Also: Wallpaper updates with `swww` are way more elegant since they will fade over by default. :grin: 

I took the liberty to wrap `swaybg` into the check for `WAYLAND_DISPLAY` since… if it doesn't exist, there is no need to trying `swaybg` at all.